### PR TITLE
Add support for proxying the new API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ environment variables:
 
 * `MAX_REQUESTS`: Default 30.
 * `MS_TIMEOUT`: Default 7000 (7 seconds)
+
+## Tests
+
+`npm test`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # One Bus Away API Proxy
 
+## Setup 
+
+Copy `sample.env` to `.env` and fill in with the correct variables
+
+## Run
+
+`node proxy.js`
+
 ## Rate limiting 
 
 These configuration settings have sensible defaults but can be overridden by 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,12 +1,16 @@
 'use strict';
 
+require('dotenv').config();
+
 var settings = module.exports;
 
 settings.api = process.env.OBA_API;
+settings.newAPI = process.env.NEW_OBA_API;
 settings.port = process.env.PORT || 3001;
 settings.apiKey = process.env.OBA_API_KEY || 'BETA';
 
 if (process.env.KEYS === undefined) {
   settings.keys = [];
 }
+
 settings.keys = JSON.parse(process.env.KEYS);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "compression": "^1.2.0",
     "connect": "~3.3.0",
+    "dotenv": "^4.0.0",
     "request": "~2.45.0"
   },
   "devDependencies": {

--- a/proxy.js
+++ b/proxy.js
@@ -26,13 +26,13 @@ app.use(compression())
   count += 1;
   console.log('info active_requests=' + count);
   
-  // Add CORS headers
-  resp.setHeader('Access-Control-Allow-Origin', '*');
-
   req.client.on('close', function () {
     count -= 1;
     console.log('info active_requests=' + count);
   });
+
+  // Add CORS headers
+  resp.setHeader('Access-Control-Allow-Origin', '*');
 
   if (count > MAX_REQUESTS) {
     resp.statusCode = 503;
@@ -48,9 +48,12 @@ app.use(compression())
 
   // Check if we should use the new API or the old API
   var urlParts = parts.pathname.split('/');
-  if (urlParts && urlParts[1] === 'v2') {
+  if (settings.newAPI && 
+      urlParts && 
+      urlParts[1] === 'v2') {
     apiURL = settings.newAPI;
-    // We need to get rid of the "v2" prefix
+
+    // We also need to get rid of the "v2" prefix
     parts.pathname = '/' + urlParts.splice(2).join('/');
   }
 
@@ -68,8 +71,6 @@ app.use(compression())
   parts.search = undefined;
   parts = u.parse(u.format(parts));
   var url = apiURL + parts.pathname + parts.search;
-
-  console.log("using URL", url);
 
 
   // Copy headers from the origin client request to our request

--- a/proxy.js
+++ b/proxy.js
@@ -16,8 +16,8 @@ var port = settings.port;
 var app = connect();
 var server = http.createServer(app);
 
-var MS_TIMEOUT = process.env.MS_TIMEOUT || 7000;
-var MAX_REQUESTS = process.env.MAX_REQUESTS || 30;
+var MS_TIMEOUT = Number(process.env.MS_TIMEOUT) || 7000;
+var MAX_REQUESTS = Number(process.env.MAX_REQUESTS) || 30;
 
 var count = 0;
 

--- a/proxy.js
+++ b/proxy.js
@@ -25,6 +25,9 @@ app.use(compression())
 .use(function (req, resp) {
   count += 1;
   console.log('info active_requests=' + count);
+  
+  // Add CORS headers
+  resp.setHeader('Access-Control-Allow-Origin', '*');
 
   req.client.on('close', function () {
     count -= 1;
@@ -40,6 +43,18 @@ app.use(compression())
   var parts = u.parse(req.url, true);
   var inboundKey = parts.query.key;
 
+
+  var apiURL = API;
+
+  // Check if we should use the new API or the old API
+  var urlParts = parts.pathname.split('/');
+  if (urlParts && urlParts[1] === 'v2') {
+    apiURL = settings.newAPI;
+    // We need to get rid of the "v2" prefix
+    parts.pathname = '/' + urlParts.splice(2).join('/');
+  }
+
+
   // Check if the provided key is valid.
   if (settings.keys.indexOf(inboundKey) === -1) {
     // Invalid key. Send a 403.
@@ -52,10 +67,10 @@ app.use(compression())
   parts.query.key = settings.apiKey;
   parts.search = undefined;
   parts = u.parse(u.format(parts));
-  var url = API + parts.pathname + parts.search;
+  var url = apiURL + parts.pathname + parts.search;
 
-  // Add CORS headers
-  resp.setHeader('Access-Control-Allow-Origin', '*');
+  console.log("using URL", url);
+
 
   // Copy headers from the origin client request to our request
   var headers = {};


### PR DESCRIPTION
I'd like to test the new API server in the wild and that requires proxying the requests. This sends requests for `/v2/....` to the new API. 

A bit hacky. If we make any more changes it's probably worth a little rewriting. 

